### PR TITLE
Feature/add color type

### DIFF
--- a/openhab/client.py
+++ b/openhab/client.py
@@ -196,6 +196,8 @@ class OpenHAB:
       return openhab.items.NumberItem(self, json_data)
     elif json_data['type'] == 'Dimmer':
       return openhab.items.DimmerItem(self, json_data)
+    elif json_data['type'] == 'Color':
+        return openhab.items.ColorItem(self, json_data)
     else:
       return openhab.items.Item(self, json_data)
 

--- a/openhab/items.py
+++ b/openhab/items.py
@@ -282,3 +282,49 @@ class DimmerItem(Item):
   def decrease(self):
     """Decrease the state of the dimmer"""
     self.command('DECREASE')
+
+
+class ColorItem(Item):
+  """ColorItem item type"""
+  types = [openhab.types.OnOffType, openhab.types.PercentType, openhab.types.IncreaseDecreaseType, openhab.types.ColorType]
+
+  def _parse_rest(self, value):
+    """Parse a REST result into a native object
+
+    Args:
+      value (str): A string argument to be converted into a str object.
+
+    Returns:
+      str: The str object as converted from the string parameter.
+    """
+    return str(value)
+
+  def _rest_format(self, value: typing.Any):
+    """Format a value before submitting to openHAB
+
+    Args:
+      value: Either a string or an integer; in the latter case we have to cast it to a string.
+
+    Returns:
+      str: The string as possibly converted from the parameter.
+    """
+    if not isinstance(value, str):
+      return str(value)
+
+    return value
+
+  def on(self):
+    """Set the state of the color to ON"""
+    self.command('ON')
+
+  def off(self):
+    """Set the state of the color to OFF"""
+    self.command('OFF')
+
+  def increase(self):
+    """Increase the state of the color"""
+    self.command('INCREASE')
+
+  def decrease(self):
+    """Decrease the state of the color"""
+    self.command('DECREASE')

--- a/openhab/types.py
+++ b/openhab/types.py
@@ -23,6 +23,7 @@
 import abc
 import datetime
 import typing
+import re
 
 __author__ = 'Georges Toth <georges@trypill.org>'
 __license__ = 'AGPLv3+'
@@ -101,6 +102,30 @@ class OpenCloseType(StringType):
 
     if value not in ['OPEN', 'CLOSED']:
       raise ValueError()
+
+
+class ColorType(StringType):
+  """ColorType type class"""
+  @classmethod
+  def validate(cls, value: str):
+    """Value validation method.
+    Valid values are in format H,S,B.
+    Value ranges:
+      H(ue): 0-360
+      S(aturation): 0-100
+      B(rightness): 0-100
+
+    Args:
+      value (str): The value to validate.
+
+    Raises:
+      ValueError: Raises ValueError if an invalid value has been specified.
+    """
+    super().validate(value)
+    h,s,b = re.split(',', value)
+    if not ((0 <= int(h) <= 360) and (0 <= int(s) <= 100) and (0 <= int(b) <= 100)):
+        raise ValueError()
+
 
 
 class DecimalType(CommandType):


### PR DESCRIPTION
We noticed that python-openhab did not support our color items.
It simply did not assign a item type and when we tried to set the state it failed.

This is how we fixed it.
Maybe you think it's worth to merge.