### PR TITLE
Add support for setting unit of measure when updating Number items

### DIFF
--- a/openhab/command_types.py
+++ b/openhab/command_types.py
@@ -297,19 +297,27 @@ class DecimalType(CommandType):
     raise ValueError()
 
   @classmethod
-  def validate(cls, value: typing.Union[float, int]) -> None:
+  def validate(cls, value: typing.Union[int, float, typing.Tuple[typing.Union[int, float], str], str]) -> None:
     """Value validation method.
 
-    Valid values are any of data_type ``float`` or ``int``.
+    Valid values are any of data_type:
+      - ``int``
+      - ``float``
+      - a tuple of (``int`` or ``float``, ``str``) for numeric value, unit of measure
+      - a ``str`` that can be parsed to one of the above by ``DecimalType.parse``
 
     Args:
-      value (float): The value to validate.
+      value (int, float, tuple, str): The value to validate.
 
     Raises:
       ValueError: Raises ValueError if an invalid value has been specified.
     """
-    if not isinstance(value, (int, float)):
-      raise ValueError()
+    if isinstance(value, str):
+        DecimalType.parse(value)
+    elif isinstance(value, tuple) and len(value) == 2:
+        DecimalType.parse(f'{value[0]} {value[1]}')
+    elif not isinstance(value, (int, float)):
+        raise ValueError()
 
 
 class PercentType(CommandType):

--- a/openhab/command_types.py
+++ b/openhab/command_types.py
@@ -279,7 +279,7 @@ class DecimalType(CommandType):
     if value in DecimalType.UNDEFINED_STATES:
       return None
 
-    m = re.match(r'(-?[0-9.]+)\s?(.*)?$', value)
+    m = re.match(r'(-?[0-9.]+(?:[eE]-?[0-9]+)?)\s?(.*)?$', value)
     if m:
       value_value = m.group(1)
       value_unit_of_measure = m.group(2)

--- a/openhab/items.py
+++ b/openhab/items.py
@@ -207,7 +207,10 @@ class Item:
 
   def __str__(self) -> str:
     """String representation."""
-    return f'<{self.type_} - {self.name} : {self._state}>'
+    state = self._state
+    if self._unitOfMeasure and not isinstance(self._state, tuple):
+        state = f'{self._state} {self._unitOfMeasure}'
+    return f'<{self.type_} - {self.name} : {state}>'
 
   def _update(self, value: typing.Any) -> None:
     """Updates the state of an item, input validation is expected to be already done.

--- a/openhab/items.py
+++ b/openhab/items.py
@@ -454,7 +454,7 @@ class NumberItem(Item):
       return None, ''
     # m = re.match(r'''^(-?[0-9.]+)''', value)
     try:
-      m = re.match(r'(-?[0-9.]+)\s?(.*)?$', value)
+      m = re.match(r'(-?[0-9.]+(?:[eE]-?[0-9]+)?)\s?(.*)?$', value)
 
       if m:
         value = m.group(1)
@@ -479,9 +479,9 @@ class NumberItem(Item):
       str or bytes: A string or bytes as converted from the value parameter.
     """
     if isinstance(value, tuple) and len(value) == 2:
-        return super()._rest_format(f'{value[0]} {value[1]}')
+        return super()._rest_format(f'{value[0]:G} {value[1]}')
     if not isinstance(value, str):
-        return super()._rest_format(str(value))
+        return super()._rest_format(f'{value:G}')
     return super()._rest_format(value)
 
 

--- a/openhab/items.py
+++ b/openhab/items.py
@@ -189,9 +189,9 @@ class Item:
     # pylint: disable=no-self-use
     _value = value  # type: typing.Union[str, bytes]
 
-    # Only latin-1 encoding is supported by default. If non-latin-1 characters were provided, convert them to bytes.
+    # Only ascii encoding is supported by default. If non-ascii characters were provided, convert them to bytes.
     try:
-      _ = value.encode('latin-1')
+      _ = value.encode('ascii')
     except UnicodeError:
       _value = value.encode('utf-8')
 

--- a/openhab/items.py
+++ b/openhab/items.py
@@ -466,16 +466,20 @@ class NumberItem(Item):
 
     raise ValueError(f'{self.__class__}: unable to parse value "{value}"')
 
-  def _rest_format(self, value: float) -> str:  # type: ignore[override]
+  def _rest_format(self, value: typing.Union[float, typing.Tuple[float, str], str]) -> typing.Union[str, bytes]:
     """Format a value before submitting to openHAB.
 
     Args:
-      value (float): A float argument to be converted into a string.
+      value: Either a float, a tuple of (float, str), or string; in the first two cases we have to cast it to a string.
 
     Returns:
-      str: The string as converted from the float parameter.
+      str or bytes: A string or bytes as converted from the value parameter.
     """
-    return str(value)
+    if isinstance(value, tuple) and len(value) == 2:
+        return super()._rest_format(f'{value[0]} {value[1]}')
+    if not isinstance(value, str):
+        return super()._rest_format(str(value))
+    return super()._rest_format(value)
 
 
 class ContactItem(Item):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -46,11 +46,14 @@ def test_float():
   assert float_obj.state == 1.0
 
 
-def test_non_latin1_string():
+def test_non_ascii_string():
   string_obj = oh.get_item('stringtest')
 
   string_obj.state = 'שלום'
   assert string_obj.state == 'שלום'
+
+  string_obj.state = '°F'
+  assert string_obj.state == '°F'
 
 
 def test_color_item():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 
 import openhab
 
@@ -87,19 +88,25 @@ def test_number_temperature():
   # the unit of measure for the 'Dining_Temperature' item
   temperature_item = oh.get_item('Dining_Temperature')
 
-  temperature_item.state = 1
-  assert temperature_item.state == 1
+  temperature_item.state = 1.0
+  time.sleep(1)  # Allow time for OpenHAB test instance to process state update
+  assert temperature_item.state == 1.0
   assert temperature_item.unit_of_measure == '°C'
 
   temperature_item.state = '2 °C'
+  time.sleep(1)
   assert temperature_item.state == 2
   assert temperature_item.unit_of_measure == '°C'
 
   temperature_item.state = (3, '°C')
+  time.sleep(1)
   assert temperature_item.state == 3
   assert temperature_item.unit_of_measure == '°C'
 
   # Unit of measure conversion (performed by OpenHAB server)
   temperature_item.state = (32, '°F')
   assert round(temperature_item.state, 2) == 0
+  temperature_item.state = (212, '°F')
+  time.sleep(1)
+  assert temperature_item.state == 100
   assert temperature_item.unit_of_measure == '°C'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -73,3 +73,26 @@ def test_color_item():
 
   coloritem.state = 'ON'
   assert coloritem.state == (1.1, 1.2, 100.0)
+
+
+def test_number_temperature():
+  # Tests below require the OpenHAB test instance to be configured with '°C' as
+  # the unit of measure for the 'Dining_Temperature' item
+  temperature_item = oh.get_item('Dining_Temperature')
+
+  temperature_item.state = 1
+  assert temperature_item.state == 1
+  assert temperature_item.unit_of_measure == '°C'
+
+  temperature_item.state = '2 °C'
+  assert temperature_item.state == 2
+  assert temperature_item.unit_of_measure == '°C'
+
+  temperature_item.state = (3, '°C')
+  assert temperature_item.state == 3
+  assert temperature_item.unit_of_measure == '°C'
+
+  # Unit of measure conversion (performed by OpenHAB server)
+  temperature_item.state = (32, '°F')
+  assert temperature_item.state == 0
+  assert temperature_item.unit_of_measure == '°C'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -51,6 +51,7 @@ def test_scientific_notation():
   float_obj = oh.get_item('floattest')
 
   float_obj.state = 1e-10
+  time.sleep(1)  # Allow time for OpenHAB test instance to process state update
   assert float_obj.state == 1e-10
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -46,6 +46,13 @@ def test_float():
   assert float_obj.state == 1.0
 
 
+def test_scientific_notation():
+  float_obj = oh.get_item('floattest')
+
+  float_obj.state = 1e-10
+  assert float_obj.state == 1e-10
+
+
 def test_non_ascii_string():
   string_obj = oh.get_item('stringtest')
 
@@ -94,5 +101,5 @@ def test_number_temperature():
 
   # Unit of measure conversion (performed by OpenHAB server)
   temperature_item.state = (32, '°F')
-  assert temperature_item.state == 0
+  assert round(temperature_item.state, 2) == 0
   assert temperature_item.unit_of_measure == '°C'

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -88,5 +88,28 @@ def test_color_item():
   assert coloritem.state == (1.1, 1.2, 100.0)
 
 
+def test_number_temperature():
+  # Tests below require the OpenHAB test instance to be configured with '°C' as
+  # the unit of measure for the 'Dining_Temperature' item
+  temperature_item = oh.get_item('Dining_Temperature')
+
+  temperature_item.state = 1
+  assert temperature_item.state == 1
+  assert temperature_item.unit_of_measure == '°C'
+
+  temperature_item.state = '2 °C'
+  assert temperature_item.state == 2
+  assert temperature_item.unit_of_measure == '°C'
+
+  temperature_item.state = (3, '°C')
+  assert temperature_item.state == 3
+  assert temperature_item.unit_of_measure == '°C'
+
+  # Unit of measure conversion (performed by OpenHAB server)
+  temperature_item.state = (32, '°F')
+  assert temperature_item.state == 0
+  assert temperature_item.unit_of_measure == '°C'
+
+
 def test_session_logout():
   assert oh.logout()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -59,6 +59,13 @@ def test_float():
   assert float_obj.state == 1.0
 
 
+def test_scientific_notation():
+  float_obj = oh.get_item('floattest')
+
+  float_obj.state = 1e-10
+  assert float_obj.state == 1e-10
+
+
 def test_non_ascii_string():
   string_obj = oh.get_item('stringtest')
 
@@ -107,7 +114,7 @@ def test_number_temperature():
 
   # Unit of measure conversion (performed by OpenHAB server)
   temperature_item.state = (32, '°F')
-  assert temperature_item.state == 0
+  assert round(temperature_item.state, 2) == 0
   assert temperature_item.unit_of_measure == '°C'
 
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import pathlib
+import time
 
 import openhab.oauth2_helper
 
@@ -100,21 +101,27 @@ def test_number_temperature():
   # the unit of measure for the 'Dining_Temperature' item
   temperature_item = oh.get_item('Dining_Temperature')
 
-  temperature_item.state = 1
-  assert temperature_item.state == 1
+  temperature_item.state = 1.0
+  time.sleep(1)  # Allow time for OpenHAB test instance to process state update
+  assert temperature_item.state == 1.0
   assert temperature_item.unit_of_measure == '°C'
 
   temperature_item.state = '2 °C'
+  time.sleep(1)
   assert temperature_item.state == 2
   assert temperature_item.unit_of_measure == '°C'
 
   temperature_item.state = (3, '°C')
+  time.sleep(1)
   assert temperature_item.state == 3
   assert temperature_item.unit_of_measure == '°C'
 
   # Unit of measure conversion (performed by OpenHAB server)
   temperature_item.state = (32, '°F')
   assert round(temperature_item.state, 2) == 0
+  temperature_item.state = (212, '°F')
+  time.sleep(1)
+  assert temperature_item.state == 100
   assert temperature_item.unit_of_measure == '°C'
 
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -59,11 +59,14 @@ def test_float():
   assert float_obj.state == 1.0
 
 
-def test_non_latin1_string():
+def test_non_ascii_string():
   string_obj = oh.get_item('stringtest')
 
   string_obj.state = 'שלום'
   assert string_obj.state == 'שלום'
+
+  string_obj.state = '°F'
+  assert string_obj.state == '°F'
 
 
 def test_color_item():

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -64,6 +64,7 @@ def test_scientific_notation():
   float_obj = oh.get_item('floattest')
 
   float_obj.state = 1e-10
+  time.sleep(1)  # Allow time for OpenHAB test instance to process state update
   assert float_obj.state == 1e-10
 
 


### PR DESCRIPTION
@sim0nx, first of all, thank you for this great library for communicating with the OpenHAB REST API.

This PR adds support for updating OpenHAB Number items of QuantityType and setting the unit of measure. Currently, the library only supports retrieving the unit of measure. In my specific case, I was trying to update a Number:Temperature item that is stored in OpenHAB in Fahrenheit, using values from a sensor that only reports in Celsius. OpenHAB can handle the unit conversion as long as the string sent to the REST API includes the proper unit of measure, but `NumberItem.update()` could only be called with a `float` or `int`. This PR allows the `NumberItem.update()` and `NumberItem.command()` methods to also accept a string of the form "[numeric value] [unit of measure]" or a tuple of `(float, str)` to represent numbers with units.

While adding this feature, I also discovered that the OpenHAB REST API does not support the full latin-1 encoding but only accepts ascii or utf-8. If the degree symbol (°) is encoded as latin-1 (as is the default when a `str` is provided as data to the underlying requests library), my OpenHAB server (v3.1.0) returned a Bad Request error when updating the Number item. However, encoding as utf-8 was fine. A similar problem occurred if a degree symbol was set in a String item: the value was accepted but improperly decoded. Therefore, I switched the check for non-latin-1 characters to check for non-ascii characters. We could also consider always encoding the final string to utf-8 for simplicity.

Lastly, the unit of measure was also exposed in the `Item.__str__()` method.

Thanks for considering this PR.